### PR TITLE
Support for ISO 14230-2 KWP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 OBD9141
-======
+=======
 
-This is a library to read data from the the ISO 9141-2 (K-line) pin of an [OBD-II][obd2] port found in cars.
+This is a library to read data from the [OBD-II][obd2] port through the K-line pin using either ISO 9141-2 or ISO 14230-2 (KWP).
 
 There are numerous projects which read data from the diagnostic port and display or record this. However, I found that most of these projects either use an ELM327 chip or the communication code is interwoven with the rest of the program. This makes it hard to extract the communication parts for use in another project.
 
@@ -11,7 +11,7 @@ Usage
 --------
 The code has been developed using [Teensy 3][teensy31], the K-line transceiver IC's used were during the development were the [MC33290][mc33290], [SN65HVDA100][SN65HVDA100] and [SN65HVDA195][SN65HVDA195]. All three transceiver IC's worked without problems when the typical application circuit from the datasheet was used. The OBD9141 class itself has been tested on one Kia car build in 2004.
 
-For the Teensy 3.x or LC versions it is recommended to use one of the HardwareSerial ports. For use with Arduino the [AltSoftSerial][altsoftserial] library is used by default. The example `reader_softserial` was tested with an Arduino UNO.
+For the Teensy 3.x or LC versions it is recommended to use one of the HardwareSerial ports. For use with Arduino the [AltSoftSerial][altsoftserial] library is used by default. The example `reader_softserial` was tested with an Arduino UNO. The KWP functionality of this library was verified to work on a Teensy 3.5.
 
 A minimal example of how to use the SN65HVDA195 chip mentioned is given by the following schematic:
 ![Schematic of circuit using SN65HVDA195](/../master/extras/OBD9141_reader/img/OBD9141_reader_cutout.png?raw=true "Schematic of circuit using SN65HVDA195")
@@ -45,6 +45,10 @@ Contrary to reading the normal OBD PID's, when trouble codes are read from the E
 
 The following trouble-code related modes are supported: Reading stored trouble codes (mode `0x03`), clearing trouble codes (mode `0x04`) and reading pending trouble codes (mode `0x07`).
 
+ISO 14230-2 (KWP)
+-----------------
+The [ISO 14230-2][KWP] protocol uses the same physical layer as 9141-2, the support for this protocol was developed under [issue #11](https://github.com/iwanders/OBD9141/issues/11). If `initKWP()` is called instead of `init()` the KWP protocol is used for all requests onward. The provided functionality should be the same regardless of the protocol used. A sketch that just tests the KWP functionality is available [`readerKWP`](examples/readerKWP/readerKWP.ino).
+
 License
 ------
 MIT License, see LICENSE.md.
@@ -59,3 +63,4 @@ Copyright (c) 2015 Ivor Wanders
 [SN65HVDA100]:http://www.ti.com/product/sn65hvda100-q1
 [saleae]:https://www.saleae.com/
 [altsoftserial]:https://www.pjrc.com/teensy/td_libs_AltSoftSerial.html
+[KWP]:https://en.wikipedia.org/wiki/Keyword_Protocol_2000

--- a/examples/T3_ILI9341_display/T3_ILI9341_display.ino
+++ b/examples/T3_ILI9341_display/T3_ILI9341_display.ino
@@ -70,7 +70,7 @@ typedef struct{
 } obd_unit;
 
 typedef struct{
-  uint32_t old_value;
+  int32_t old_value;
   elapsedMillis timesince;
 } obd_unit_state;
 

--- a/examples/reader/reader.ino
+++ b/examples/reader/reader.ino
@@ -57,6 +57,7 @@ void loop(){
 
             delay(200);
         }
+        delay(200);
     }
     delay(3000);
 }

--- a/examples/readerDUE/readerDUE.ino
+++ b/examples/readerDUE/readerDUE.ino
@@ -65,6 +65,7 @@ void loop(){
 
             delay(200);
         }
+        delay(200);
     }
     delay(3000);
 }

--- a/examples/readerKWP/readerKWP.ino
+++ b/examples/readerKWP/readerKWP.ino
@@ -27,6 +27,7 @@ void loop(){
     bool init_success =  obd.initKWP();
     Serial.print("init_success:");
     Serial.println(init_success);
+    delay(50);
 
     //init_success = true;
     // Uncomment this line if you use the simulator to force the init to be
@@ -41,12 +42,14 @@ void loop(){
                 Serial.print("Result 0x11 (throttle): ");
                 Serial.println(obd.readUint8());
             }
+            delay(50);
             
             res = obd.getCurrentPID(0x0C, 2);
             if (res){
                 Serial.print("Result 0x0C (RPM): ");
                 Serial.println(obd.readUint16()/4);
             }
+            delay(50);
 
 
             res = obd.getCurrentPID(0x0D, 1);

--- a/examples/readerKWP/readerKWP.ino
+++ b/examples/readerKWP/readerKWP.ino
@@ -1,0 +1,67 @@
+#include "Arduino.h"
+#include "OBD9141.h"
+
+#define RX_PIN 0
+#define TX_PIN 1
+#define EN_PIN 2
+
+
+OBD9141 obd;
+
+
+void setup(){
+    Serial.begin(9600);
+    delay(2000);
+
+    pinMode(EN_PIN, OUTPUT);
+    digitalWrite(EN_PIN, HIGH);
+
+    obd.begin(Serial1, RX_PIN, TX_PIN);
+
+}
+    
+void loop(){
+    Serial.println("Looping");
+
+    // only change from reader is the init method here.
+    bool init_success =  obd.initKWP();
+    Serial.print("init_success:");
+    Serial.println(init_success);
+
+    //init_success = true;
+    // Uncomment this line if you use the simulator to force the init to be
+    // interpreted as successful. With an actual ECU; be sure that the init is 
+    // succesful before trying to request PID's.
+
+    if (init_success){
+        bool res;
+        while(1){
+            res = obd.getCurrentPID(0x11, 1);
+            if (res){
+                Serial.print("Result 0x11 (throttle): ");
+                Serial.println(obd.readUint8());
+            }
+            
+            res = obd.getCurrentPID(0x0C, 2);
+            if (res){
+                Serial.print("Result 0x0C (RPM): ");
+                Serial.println(obd.readUint16()/4);
+            }
+
+
+            res = obd.getCurrentPID(0x0D, 1);
+            if (res){
+                Serial.print("Result 0x0D (speed): ");
+                Serial.println(obd.readUint8());
+            }
+            Serial.println();
+
+            delay(200);
+        }
+    }
+    delay(3000);
+}
+
+
+
+

--- a/examples/readerKWP/readerKWP.ino
+++ b/examples/readerKWP/readerKWP.ino
@@ -58,6 +58,7 @@ void loop(){
 
             delay(200);
         }
+        delay(200);
     }
     delay(3000);
 }

--- a/src/OBD9141.cpp
+++ b/src/OBD9141.cpp
@@ -117,8 +117,13 @@ bool OBD9141::request9141(void* request, uint8_t request_len, uint8_t ret_len){
 uint8_t OBD9141::request(void* request, uint8_t request_len){
     if (use_kwp_)
     {
-        // kwp request is always variable length.
-        return requestKWP(request, request_len);
+        // have to modify the first bytes.
+        uint8_t rbuf[request_len];
+        memcpy(rbuf, request, request_len);
+        // now we modify the header, the payload is the request_len - 3 header bytes
+        rbuf[0] = (0b11<<6) | (request_len - 3);
+        rbuf[1] = 0x33;  // second byte should be 0x33
+        return requestKWP(rbuf, request_len);
     }
     bool success = true;
     // wipe the entire buffer to ensure we are in a clean slate.

--- a/src/OBD9141.cpp
+++ b/src/OBD9141.cpp
@@ -61,7 +61,7 @@ void OBD9141::write(uint8_t b){
 
 void OBD9141::write(void* b, uint8_t len){
     for (uint8_t i=0; i < len ; i++){
-        OBD9141print("w: ");OBD9141println(reinterpret_cast<uint8_t*>(b)[i]);
+        // OBD9141print("w: ");OBD9141println(reinterpret_cast<uint8_t*>(b)[i]);
         this->serial->write(reinterpret_cast<uint8_t*>(b)[i]);
         delay(OBD9141_INTERSYMBOL_WAIT);
     }
@@ -102,10 +102,10 @@ bool OBD9141::request9141(void* request, uint8_t request_len, uint8_t ret_len){
     
     //OBD9141print("Trying to get x bytes: "); OBD9141println(ret_len+1);
     if (this->serial->readBytes(this->buffer, ret_len+1)){
-        OBD9141print("R: ");
-        for (uint8_t i=0; i< (ret_len+1); i++){
-            OBD9141print(this->buffer[i]);OBD9141print(" ");
-        };OBD9141println();
+        // OBD9141print("R: ");
+        // for (uint8_t i=0; i< (ret_len+1); i++){
+            // OBD9141print(this->buffer[i]);OBD9141print(" ");
+        // };OBD9141println();
         
         return (this->checksum(&(this->buffer[0]), ret_len) == this->buffer[ret_len]);// have data; return whether it is valid.
     } else {
@@ -472,8 +472,6 @@ bool OBD9141::initKWP(){
     }
     return false;
 }
-
-
 
 void OBD9141::decodeDTC(uint16_t input_bytes, uint8_t* output_string){
   const uint8_t A = reinterpret_cast<uint8_t*>(&input_bytes)[0];

--- a/src/OBD9141.cpp
+++ b/src/OBD9141.cpp
@@ -196,7 +196,9 @@ uint8_t OBD9141::requestKWP(void* request, uint8_t request_len){
     // This means that we should now read the 2 addressing bytes, the payload
     // and the checksum byte.
     const uint8_t remainder = msg_len + 2 + 1;
+    OBD9141print("Rem: ");OBD9141println(remainder);
     const uint8_t ret_len = remainder + 1;
+    OBD9141print("ret_len: ");OBD9141println(ret_len);
     this->serial->setTimeout(OBD9141_REQUEST_ANSWER_MS_PER_BYTE * remainder + OBD9141_WAIT_FOR_REQUEST_ANSWER_TIMEOUT);
 
     //OBD9141print("Trying to get x bytes: "); OBD9141println(ret_len+1);
@@ -206,7 +208,11 @@ uint8_t OBD9141::requestKWP(void* request, uint8_t request_len){
             OBD9141print(this->buffer[i]);OBD9141print(" ");
         };OBD9141println();
   
-        if (this->checksum(&(this->buffer[0]), ret_len) == this->buffer[ret_len])
+        const uint8_t calc_checksum = this->checksum(&(this->buffer[0]), ret_len - 1);
+        OBD9141print("calc cs: ");OBD9141println(calc_checksum);
+        OBD9141print("buf cs: ");OBD9141println(this->buffer[ret_len]);
+        
+        if (calc_checksum == this->buffer[ret_len])
         {
           return ret_len; // have data; return whether it is valid.
         }

--- a/src/OBD9141.cpp
+++ b/src/OBD9141.cpp
@@ -225,7 +225,7 @@ uint8_t OBD9141::requestKWP(void* request, uint8_t request_len){
     OBD9141print("Rem: ");OBD9141println(remainder);
     const uint8_t ret_len = remainder + 1;
     OBD9141print("ret_len: ");OBD9141println(ret_len);
-    this->serial->setTimeout(OBD9141_REQUEST_ANSWER_MS_PER_BYTE * remainder + OBD9141_WAIT_FOR_REQUEST_ANSWER_TIMEOUT);
+    this->serial->setTimeout(OBD9141_REQUEST_ANSWER_MS_PER_BYTE * (remainder + 1));
 
     //OBD9141print("Trying to get x bytes: "); OBD9141println(ret_len+1);
     if (this->serial->readBytes(&(this->buffer[1]), remainder)){

--- a/src/OBD9141.cpp
+++ b/src/OBD9141.cpp
@@ -240,7 +240,7 @@ uint8_t OBD9141::requestKWP(void* request, uint8_t request_len){
         
         if (calc_checksum == this->buffer[ret_len - 1])
         {
-          return ret_len; // have data; return whether it is valid.
+          return ret_len - 1; // have data; return whether it is valid.
         }
     } else {
         OBD9141println("Timeout on reading bytes.");
@@ -461,7 +461,7 @@ bool OBD9141::initKWP(){
     // checksum (0x66) is calculated by request method.
 
     // Send this request and read the response
-    if (this->requestKWP(&message, 4) == 7) {
+    if (this->requestKWP(&message, 4) == 6) {
         // check positive response service ID, should be 0xC1.
         if (this->buffer[3] == 0xC1) {
             // Not necessary to do anything with this data?

--- a/src/OBD9141.cpp
+++ b/src/OBD9141.cpp
@@ -210,9 +210,9 @@ uint8_t OBD9141::requestKWP(void* request, uint8_t request_len){
   
         const uint8_t calc_checksum = this->checksum(&(this->buffer[0]), ret_len - 1);
         OBD9141print("calc cs: ");OBD9141println(calc_checksum);
-        OBD9141print("buf cs: ");OBD9141println(this->buffer[ret_len]);
+        OBD9141print("buf cs: ");OBD9141println(this->buffer[ret_len - 1]);
         
-        if (calc_checksum == this->buffer[ret_len])
+        if (calc_checksum == this->buffer[ret_len - 1])
         {
           return ret_len; // have data; return whether it is valid.
         }

--- a/src/OBD9141.h
+++ b/src/OBD9141.h
@@ -8,7 +8,7 @@
 #include "Arduino.h"
 
 // to do some debug printing.
-#define OBD9141_DEBUG
+// #define OBD9141_DEBUG
 
 //#define OBD9141_USE_ALTSOFTSERIAL
 // use AltSoftSerial.h instead of the hardware Serial
@@ -57,7 +57,7 @@
 // The ECU might not push all bytes on the bus immediately, but wait several ms
 // between the bytes, this is the time allowed per byte for the answer
 
-#define OBD9141_WAIT_FOR_REQUEST_ANSWER_TIMEOUT (30 + 10)
+#define OBD9141_WAIT_FOR_REQUEST_ANSWER_TIMEOUT (30 + 20)
 // Time added to the read timeout when reading the response to a request. 
 // This should incorporate the 30 ms that's between the request and answer
 // according to the specification.

--- a/src/OBD9141.h
+++ b/src/OBD9141.h
@@ -115,7 +115,6 @@ class OBD9141{
 
         uint8_t buffer[OBD9141_BUFFER_SIZE]; // internal buffer.
 
-
     public:
         OBD9141();
 
@@ -149,6 +148,16 @@ class OBD9141{
          */
         uint8_t request(void* request, uint8_t request_len);
 
+        /**
+         * @brief Send a request and read return bytes according to KWP protocol
+         * @param request The pointer to read the address from.
+         * @param request_len the length of the request.
+         * @return the number of bytes read if checksum matches.
+         * @note If checksum doesn't match return will be zero, but bytes will
+         *       still be written to the internal buffer.
+         */
+        uint8_t requestKWP(void* request, uint8_t request_len);
+
         // The following methods only work to read values from PID mode 0x01
         uint8_t readUint8(); // returns right part from the buffer as uint8_t
         uint16_t readUint16(); // idem...
@@ -174,7 +183,7 @@ class OBD9141{
         // need to enable the port if we want to skip the init.
 
         bool init(); // attempts 'slow' ISO9141 5 baud init.
-        bool init_kwp_fast();  // attempts kwp2000 fast init.
+        bool initKWP();  // attempts kwp2000 fast init.
         // returns whether the procedure was finished correctly.
         // The class keeps no track of whether this was successful or not.
         // It is up to the user to ensure that the initialisation is called.

--- a/src/OBD9141.h
+++ b/src/OBD9141.h
@@ -115,6 +115,7 @@ class OBD9141{
 
         uint8_t buffer[OBD9141_BUFFER_SIZE]; // internal buffer.
 
+        bool use_kwp_;
     public:
         OBD9141();
 
@@ -131,12 +132,22 @@ class OBD9141{
         // Sends a request containing {0x68, 0x6A, 0xF1, mode, pid}
         // Returns whether the request was answered with a correct answer
         // (correct PID and checksum)
-        
+
+        /**
+         * @brief Send a request to the ECU, includes header bytes. For KWP the
+         *        first two header bytes will be corrected before transmission.
+         * @param request Pointer to the request bytes.
+         * @param request_len The number of bytes that make up the request.
+         * @param ret_len The expected return length.
+         *
+         * Sends buffer at request, up to request_len, adds a checksum.
+         * Needs to know the returned number of bytes, checks if the appropiate
+         * length was returned and if the checksum matches.
+         * User needs to ensure that the ret_len never exceeds the buffer size.
+         * if initKWP has been called, the requestKWP will be called.
+         */
         bool request(void* request, uint8_t request_len, uint8_t ret_len);
-        // Sends buffer at request, up to request_len, adds a checksum.
-        // Needs to know the returned number of bytes, checks if the appropiate
-        // length was returned and if the checksum matches.
-        // User needs to ensure that the ret_len never exceeds the buffer size.
+        bool request9141(void* request, uint8_t request_len, uint8_t ret_len);
 
         /**
          * @brief Send a request with a variable number of return bytes.

--- a/src/OBD9141.h
+++ b/src/OBD9141.h
@@ -8,7 +8,7 @@
 #include "Arduino.h"
 
 // to do some debug printing.
-// #define OBD9141_DEBUG
+#define OBD9141_DEBUG
 
 //#define OBD9141_USE_ALTSOFTSERIAL
 // use AltSoftSerial.h instead of the hardware Serial
@@ -174,6 +174,7 @@ class OBD9141{
         // need to enable the port if we want to skip the init.
 
         bool init(); // attempts 'slow' ISO9141 5 baud init.
+        bool init_kwp_fast();  // attempts kwp2000 fast init.
         // returns whether the procedure was finished correctly.
         // The class keeps no track of whether this was successful or not.
         // It is up to the user to ensure that the initialisation is called.


### PR DESCRIPTION
This adds the ISO 14230-2 KWP support to the `master` branch. Confirmed today that the 9141-2 functionality on this branch is unaffected using the Display example. This closes #11, closes #5 