### PR TITLE
Remove unnecessary and not portable min().

### DIFF
--- a/src/OBD9141.cpp
+++ b/src/OBD9141.cpp
@@ -176,7 +176,7 @@ uint8_t OBD9141::request(void* request, uint8_t request_len){
 
     OBD9141println();OBD9141print("A (");OBD9141print(answer_length);OBD9141print("): ");
 #ifdef OBD9141_DEBUG
-    for (uint8_t i=0; i < min(answer_length, OBD9141_BUFFER_SIZE); i++){
+    for (uint8_t i=0; i < answer_length; i++){
         OBD9141print(this->buffer[i]);OBD9141print(" ");
     };OBD9141println();
 #endif


### PR DESCRIPTION
The check is enforced by line 171.

This caused an issue in #35;

```
C:\Users\USER\Documents\Arduino\libraries\OBD9141-master\src\OBD9141.cpp:179:65: error: no matching function for call to 'min(uint8_t&, int)'
     for (uint8_t i=0; i < min(answer_length, OBD9141_BUFFER_SIZE); i++){
                                                                 ^
```

Compiling for arduino 1.8.5 (which I had on my computer, more recent version may be different?) gives;
```
OBD9141.cpp:179:27: error: 'min' was not declared in this scope
     for (uint8_t i=0; i < min<uint8_t>(answer_length, OBD9141_BUFFER_SIZE); i++){
                           ^
OBD9141.cpp:179:38: error: expected primary-expression before '>' token
     for (uint8_t i=0; i < min<uint8_t>(answer_length, OBD9141_BUFFER_SIZE); i++){
                                      ^
exit status 1
```

Ultimately, it doesn't matter as the check [here](https://github.com/iwanders/OBD9141/blob/f1a913b2d7945e2c47b744fb25903ce844258921/src/OBD9141.cpp#L171) enforces that `answer_length` is always less than or equal to `OBD9141_BUFFER_SIZE`. So I'm confident we can remove this non-portable `min` call.